### PR TITLE
Live join support

### DIFF
--- a/lib/joinstream.js
+++ b/lib/joinstream.js
@@ -4,8 +4,8 @@ var Transform = require("stream").Transform
   , utilities = require("./utilities")
   , queryMask = utilities.queryMask
   , variablesMask = utilities.variablesMask
-  , maskUpdater
-  , matcher;
+  , maskUpdater = utilities.maskUpdater
+  , matcher = utilities.matcher;
 
 function JoinStream(options) {
   if (!(this instanceof JoinStream)) {
@@ -59,38 +59,3 @@ JoinStream.prototype._transform = function(context, encoding, done) {
 };
 
 module.exports = JoinStream;
-
-matcher = function(pattern) {
-  var variables = variablesMask(pattern);
-  return function(context, triple) {
-    var bindable = Object.keys(variables).every(function(key) {
-      var variable = variables[key];
-      return variable.isBindable(context, triple[key]);
-    });
-
-    if (!bindable) {
-      return false;
-    }
-  
-    return Object.keys(variables).reduce(function(newContext, key) {
-      var variable = variables[key];
-      return variable.bind(newContext, triple[key]);
-    }, context);
-  };
-};
-
-maskUpdater = function(pattern) {
-  var variables = variablesMask(pattern);
-  return function(context, mask) {
-    return Object.keys(variables).reduce(function(newMask, key) {
-      var variable = variables[key];
-      if (variable.isBound(context)) {
-        newMask[key] = context[variable.name];
-      }
-      return newMask;
-    }, Object.keys(mask).reduce(function(acc, key) {
-      acc[key] = mask[key];
-      return acc;
-    }, {}));
-  };
-};

--- a/lib/levelgraph.js
+++ b/lib/levelgraph.js
@@ -1,5 +1,6 @@
 
-var keyfilter = require("./keyfilterstream")
+var hooks = require("level-hooks")
+  , keyfilter = require("./keyfilterstream")
   , materializer = require("./materializerstream")
   , Variable = require("./variable")
   , Navigator = require("./navigator")
@@ -17,6 +18,8 @@ var joinDefaults = {
 };
 
 module.exports = function levelgraph(leveldb, options) {
+
+  hooks(leveldb);
 
   options = options || {};
 
@@ -38,6 +41,7 @@ module.exports = function levelgraph(leveldb, options) {
       , nav: function(start) {
           return new Navigator({ start: start, db: this });
         }
+      , _leveldb: leveldb
   };
 
   return db;
@@ -75,7 +79,9 @@ joinStream = function(db, options) {
       });
 
       streams[0].start = true;
-      streams[0].end(options.context);
+      if (streams[0].end) {
+        streams[0].end(options.context);
+      }
 
       if (options.materialized) {
         streams.push(materializer({

--- a/lib/livejoinstream.js
+++ b/lib/livejoinstream.js
@@ -1,0 +1,58 @@
+
+var Readable = require("stream").Readable
+  , Variable = require("./variable")
+  , utilities = require("./utilities")
+  , queryMask = utilities.queryMask
+  , createQuery = utilities.createQuery
+  , variablesMask = utilities.variablesMask
+  , matcher = utilities.matcher;
+
+function LiveJoinStream(options) {
+  if (!(this instanceof LiveJoinStream)) {
+    return new LiveJoinStream(options);
+  }
+
+  options.objectMode = true;
+
+  Readable.call(this, options);
+  
+  this.triple = options.triple;
+  this.matcher = matcher(options.triple);
+  this.query = createQuery(queryMask(options.triple));
+  this.db = options.db;
+  this._index = options.index;
+
+  var that = this;
+
+  this._queue = [];
+  this._remover = this.db._leveldb.hooks.post(this.query, function(data) {
+    console.log(data);
+    var triple = data.value
+      , newContext = that.matcher({}, JSON.parse(data.value));
+
+    if (newContext) {
+      console.log(that.push(newContext));
+    }
+  });
+}
+
+LiveJoinStream.prototype = Object.create(
+  Readable.prototype,
+  { constructor: { value: LiveJoinStream } }
+);
+
+LiveJoinStream.prototype.pipe = function(dest) {
+  var that = this;
+  dest.on("finish", function() {
+    that._remover();
+    that.emit("close");
+  });
+  return Readable.prototype.pipe.call(this, dest);
+};
+
+LiveJoinStream.prototype._read = function(bytes) {
+  // nothing to do here, we will emit when new data
+  // is fetched
+};
+
+module.exports = LiveJoinStream;

--- a/lib/livejoinstream.js
+++ b/lib/livejoinstream.js
@@ -26,12 +26,11 @@ function LiveJoinStream(options) {
 
   this._queue = [];
   this._remover = this.db._leveldb.hooks.post(this.query, function(data) {
-    console.log(data);
     var triple = data.value
       , newContext = that.matcher({}, JSON.parse(data.value));
 
     if (newContext) {
-      console.log(that.push(newContext));
+      that.push(newContext);
     }
   });
 }

--- a/lib/queryplanner.js
+++ b/lib/queryplanner.js
@@ -33,10 +33,10 @@ function queryplanner(db, options) {
       }
 
       result.sort(function compare(a, b) {
-        if (a.size < b.size) {
+        if (a.live || a.size < b.size) {
           return -1;
         }
-        if (a.size > b.size) {
+        if (b.live || a.size > b.size) {
           return 1;
         }
         return 0;

--- a/lib/queryplanner.js
+++ b/lib/queryplanner.js
@@ -2,14 +2,15 @@
 var utilities = require("./utilities")
   , queryMask = utilities.queryMask
   , JoinStream = require("./joinstream")
+  , LiveJoinStream = require("./livejoinstream")
   , SortJoinStream = require("./sortjoinstream")
   , doSortQueryPlan
   , async = require("async");
 
 function queryplanner(db, options) {
   return function planner(query, callback) {
-    // dupes!
-    var result = [].concat(query);
+    var result = [].concat(query)
+      , live   = false
 
     async.parallel(query.map(function(q) {
       return function(cb) {
@@ -42,11 +43,18 @@ function queryplanner(db, options) {
       });
 
       result.forEach(function(q) {
+        if (q.live) {
+          live = true;
+        }
         delete q.size;
+        delete q.live;
       });
 
-      if (options.joinAlgorithm === "sort" && result.length > 1) {
-        //doSortQueryPlan(result);
+      if (live) {
+        result[0].stream = LiveJoinStream;
+      }
+
+      if (!live && options.joinAlgorithm === "sort" && result.length > 1) {
         result.reduce(doSortQueryPlan);
       }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -149,3 +149,38 @@ module.exports.queryMask = objectMask.bind(null, function(triple, key) {
 module.exports.variablesMask = objectMask.bind(null, function(triple, key) {
   return triple[key] instanceof Variable;
 });
+
+module.exports.matcher = function(pattern) {
+  var variables = module.exports.variablesMask(pattern);
+  return function(context, triple) {
+    var bindable = Object.keys(variables).every(function(key) {
+      var variable = variables[key];
+      return variable.isBindable(context, triple[key]);
+    });
+
+    if (!bindable) {
+      return false;
+    }
+  
+    return Object.keys(variables).reduce(function(newContext, key) {
+      var variable = variables[key];
+      return variable.bind(newContext, triple[key]);
+    }, context);
+  };
+};
+
+module.exports.maskUpdater = function(pattern) {
+  var variables = module.exports.variablesMask(pattern);
+  return function(context, mask) {
+    return Object.keys(variables).reduce(function(newMask, key) {
+      var variable = variables[key];
+      if (variable.isBound(context)) {
+        newMask[key] = context[variable.name];
+      }
+      return newMask;
+    }, Object.keys(mask).reduce(function(acc, key) {
+      acc[key] = mask[key];
+      return acc;
+    }, {}));
+  };
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "xtend": "~2.0.3",
     "callback-stream": "~1.0.0",
-    "async": "~0.2.8"
+    "async": "~0.2.8",
+    "level-hooks": "~4.3.2"
   },
   "peerDependencies": {
     "level": "~0.9.0"

--- a/test/live_join_spec.js
+++ b/test/live_join_spec.js
@@ -42,4 +42,36 @@ describe("live join algorithm", function() {
       });
     });
   });
+
+  it("should match triples coming from db changes with multiple conditions", function(done) {
+    var contexts = [{ coder: "matteo", friend: "daniele" }]
+        stream = db.joinStream([{ 
+            subject: db.v("coder")
+          , predicate: "does"
+          , object: "code"
+          , live: true
+        }, {
+            subject: db.v("person")
+          , predicate: "friend"
+          , object: db.v("friend")
+        }]);
+
+    stream.on("data", function(data) {
+      expect(data).to.eql(contexts.shift());
+      stream.end();
+    });
+
+    stream.on("end", function() {
+      expect(contexts.length).to.equal(0);
+      done();
+    });
+
+    stream.on("pipe", function() {
+      db.put({
+          subject: "matteo"
+        , predicate: "does"
+        , object: "code"
+      });
+    });
+  });
 });

--- a/test/live_join_spec.js
+++ b/test/live_join_spec.js
@@ -1,0 +1,45 @@
+
+var levelgraph = require("../");
+var level = require("level-test")();
+
+describe("live join algorithm", function() {
+
+  var db;
+
+  beforeEach(function(done) {
+    db = levelgraph(level());
+    db.put(require("./fixture/foaf"), done);
+  });
+
+  afterEach(function(done) {
+    db.close(done);
+  });
+
+  it("should match triples coming from db changes", function(done) {
+    var contexts = [{ activity: "code" }]
+        stream = db.joinStream([{ 
+            subject: "matteo"
+          , predicate: "does"
+          , object: db.v("activity")
+          , live: true
+        }]);
+
+    stream.on("data", function(data) {
+      expect(data).to.eql(contexts.shift());
+      stream.end();
+    });
+
+    stream.on("end", function() {
+      expect(contexts.length).to.equal(0);
+      done();
+    });
+
+    stream.on("pipe", function() {
+      db.put({
+          subject: "matteo"
+        , predicate: "does"
+        , object: "code"
+      });
+    });
+  });
+});

--- a/test/live_join_spec.js
+++ b/test/live_join_spec.js
@@ -51,7 +51,7 @@ describe("live join algorithm", function() {
           , object: "code"
           , live: true
         }, {
-            subject: db.v("person")
+            subject: db.v("coder")
           , predicate: "friend"
           , object: db.v("friend")
         }]);

--- a/test/queryplanner_spec.js
+++ b/test/queryplanner_spec.js
@@ -2,7 +2,8 @@
 var queryplanner = require("../lib/queryplanner")
   , v = require("../lib/variable")
   , SortJoinStream = require("../lib/sortjoinstream")
-  , JoinStream = require("../lib/joinstream");
+  , JoinStream = require("../lib/joinstream")
+  , LiveJoinStream = require("../lib/livejoinstream");
 
 describe("query planner", function() {
 
@@ -493,6 +494,44 @@ describe("query planner", function() {
       stub
         .withArgs("ops::marco::friend::", "ops::marco::friend\xff", sinon.match.func)
         .yields(null, 1);
+
+      planner(query, function(err, result) {
+        expect(result).to.eql(expected);
+        done();
+      });
+    });
+
+    it("should switch to JoinStream if a query is live", function(done) {
+      query = [{
+          subject: v("x")
+        , predicate: "friend"
+        , object: v("c")
+        , live: true
+      }, {
+          subject: v("x")
+        , predicate: "abc"
+        , object: v("c")
+      }];
+      
+      expected = [{
+          subject: v("x")
+        , predicate: "friend"
+        , object: v("c")
+        , stream: LiveJoinStream
+      }, {
+          subject: v("x")
+        , predicate: "abc"
+        , object: v("c")
+        , stream: JoinStream
+      }];
+
+      stub
+        .withArgs("pos::friend::", "pos::friend\xff", sinon.match.func)
+        .yields(null, 1);
+
+      stub
+        .withArgs("pos::abc::", "pos::abc\xff", sinon.match.func)
+        .yields(null, 10);
 
       planner(query, function(err, result) {
         expect(result).to.eql(expected);

--- a/test/queryplanner_spec.js
+++ b/test/queryplanner_spec.js
@@ -538,5 +538,43 @@ describe("query planner", function() {
         done();
       });
     });
+
+    it("should always put a live condition at the beginning", function(done) {
+      query = [{
+          subject: v("x")
+        , predicate: "friend"
+        , object: v("c")
+        , live: true
+      }, {
+          subject: v("x")
+        , predicate: "abc"
+        , object: v("c")
+      }];
+      
+      expected = [{
+          subject: v("x")
+        , predicate: "friend"
+        , object: v("c")
+        , stream: LiveJoinStream
+      }, {
+          subject: v("x")
+        , predicate: "abc"
+        , object: v("c")
+        , stream: JoinStream
+      }];
+
+      stub
+        .withArgs("pos::friend::", "pos::friend\xff", sinon.match.func)
+        .yields(null, 10);
+
+      stub
+        .withArgs("pos::abc::", "pos::abc\xff", sinon.match.func)
+        .yields(null, 1);
+
+      planner(query, function(err, result) {
+        expect(result).to.eql(expected);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
It seems about time to implement live join support. This is the proposed API:

```
var stream = db.joinStream([{
  live: true, // works only on the first condition
  subject: db.v('author1'),
  predicate: 'maintains',
  object: db.v('module'),
},
{
  subject: db.v('module'),
  predicate: 'depends',
  object: db.v('module2')
},
{
  subject: db.v('author2'),
  predicate: 'maintains',
  object: db.v('module2')
});
```

Note that the first `live` condition will just work on upcoming data, and the following will just be evaluated thanks to it.

Things that remains to do:
- [x] basic join support
- [x] test complex join situation
- [ ] README
- [ ] throw an error if trying to do a live query through a non-streaming method.
- [x] verify that a "live" condition is always at the top of the query plan.

Closes #3.
