### PR TITLE
In filterTwoArguments don't push falsy data - make filtering on full solutions work when are two arguments

### DIFF
--- a/lib/filterstream.js
+++ b/lib/filterstream.js
@@ -40,7 +40,7 @@ function filterTwoArguments(data, encoding, done) {
 
   // this is called only if we have a filter
   this.filter(data, function(err, data) {
-    if (!that.offset || ++that._offsetCounter > that.offset) {
+    if (data && (!that.offset || ++that._offsetCounter > that.offset)) {
       that.push(data);
     }
     done(err);

--- a/test/abstract_join_algorithm.js
+++ b/test/abstract_join_algorithm.js
@@ -321,6 +321,33 @@ module.exports = function(joinAlgorithm) {
     });
   });
 
+  it('should support solution filtering w/ 2 args', function(done) {
+    // Who's a friend of matteo and aged 25.
+    db.search([{
+      subject: db.v('s'),
+      predicate: 'age',
+      object: db.v('age'),
+    }, {
+      subject: db.v('s'),
+      predicate: 'friend',
+      object: 'matteo'
+    }], {
+      filter: function(context, callback) {
+        if (context.age == 25) {
+          callback(null, context); // confirm
+        } else {
+          callback(null); // refute
+        }
+      }
+    }, function(err, results) {
+      expect(results).to.eql([{
+        'age': 25,
+        's': 'daniele'
+      }]);
+      done();
+    });
+  });
+
   it('should return only one solution with limit 1', function(done) {
     db.search([{
       subject: db.v('x'),

--- a/test/fixture/foaf.js
+++ b/test/fixture/foaf.js
@@ -22,4 +22,20 @@ module.exports = [{
   subject: "marco",
   predicate: "friend",
   object: "davide"
+}, {
+  subject: "marco",
+  predicate: "age",
+  object: 32
+}, {
+  subject: "daniele",
+  predicate: "age",
+  object: 25
+}, {
+  subject: "lucio",
+  predicate: "age",
+  object: 15
+}, {
+  subject: "davide",
+  predicate: "age",
+  object: 70
 }];


### PR DESCRIPTION
Don't push falsy data in filterTwoArguments. Makes refuting work when filtering on full solutions.

Without this, we end up in _stream_readable.js with
 Error: stream.push() after EOF