### PR TITLE
Exact matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ LevelGraph is only possible due to the excellent work of the following contribut
 href="https://github.com/jez0990">GitHub/jez0990</a></td></tr>
 <tr><th align="left">Elf Pavlik</th><td><a href="https://github.com/elf-pavlik">GitHub/elf-pavlik</a></td><td><a href="https://twitter.com/elfpavlik">Twitter/@elfpavlik</a></td></tr>
 <tr><th align="left">Riceball LEE</th><td><a href="https://github.com/snowyu">GitHub/snowyu</a></td><td></td></tr>
+<tr><th align="left">Brian Woodward</th><td><a href="https://github.com/doowb">GitHub/doowb</a></td><td><a href="https://twitter.com/doowb">Twitter/@doowb</a></td></tr>
 </tbody></table>
 
 ## LICENSE - "MIT License"

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -138,6 +138,12 @@ function typesFromPattern(pattern) {
   });
 }
 
+function applyUpperBoundChar(key) {
+  var parts = key.split('::');
+  var len = parts.length;
+  return len === 4 && parts[len-1] !== '' ? key : key + upperBoundChar;
+}
+
 function createQuery(pattern, options) {
   var types = typesFromPattern(pattern)
     , preferiteIndex = options && options.index
@@ -145,8 +151,8 @@ function createQuery(pattern, options) {
     , key = genKey(index, pattern, '')
     , limit = pattern.limit
     , reverse = pattern.reverse || false
-    , start = reverse ? key + upperBoundChar : key
-    , end = reverse ? key : key + upperBoundChar
+    , start = reverse ? applyUpperBoundChar(key) : key
+    , end = reverse ? key : applyUpperBoundChar(key)
     , query = {
           start: start
         , end: end


### PR DESCRIPTION
Adding method to only apply the upper bound character when the key isn't complete. This ensures exact matches when the last item in the key is a subset of another item e.g. (`a` and `a1`).

This addresses #85.

I just noticed that #86 does something similar but checks the number of `types` in the `pattern`. This may be a better approach for optimization. I can make an update if it seems to be the case.

Closes #85.
Closes #86.