### PR TITLE
update leveldown dependency version for compatibility with iojs 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "readable-stream": "~1.0.17",
     "level-write-stream": "~1.0.0",
     "levelup": ">= 0.10.0 < 0.20.0",
-    "leveldown": "> 0.7.0 < 0.11.0",
+    "leveldown": "^1.0.6",
     "level-js": "~2.1.6"
   },
   "browser": {


### PR DESCRIPTION
 With the release of io.js v2.0.0 and the associated V8 upgrade, node-gyp fails to rebuild leveldown:

```
 ... 

  CXX(target) Release/obj.target/leveldown/src/database.o
../src/database.cc:552:11: warning: 'FatalException' is deprecated: Use FatalException(isolate, ...) [-Wdeprecated-declarations]
    node::FatalException(try_catch);
          ^
/Users/leon/.node-gyp/2.0.0/src/node.h:263:29: note: 'FatalException' has been explicitly marked deprecated here
                inline void FatalException(const v8::TryCatch& try_catch) {
                            ^
/Users/leon/.node-gyp/2.0.0/src/node.h:47:42: note: expanded from macro 'NODE_DEPRECATED'
    __attribute__((deprecated(message))) declarator
                                         ^
1 warning generated.

...
```

Upgrading the leveldown version solves this issue.