### PR TITLE
Expose leveldb queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,15 @@ var putBatch = db.generateBatch(triple);
 var delBatch = db.generateBatch(triple, 'del');
 ```
 
+### Generate levelup query
+
+Return the leveldb query for the given triple.
+
+```js
+var query = db.createQuery({ predicate: "b"});
+leveldb.createReadStream(query);
+```
+
 ## Navigator API
 
 The Navigator API is a fluent API for LevelGraph, loosely inspired by

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ http://nodejsconf.it.
   * [Filtering](#filtering)
   * [Putting and Deleting through Streams](#putting-and-deleting-through-streams)
   * [Generate batch operations](#generate-batch-operations)
+  * [Generate levelup query](#generate-levelup-query)
 * [Navigator API](#navigator-api)
 * [LevelUp integration](#levelup-integration)
 * [Browserify](#browserify)

--- a/lib/levelgraph.js
+++ b/lib/levelgraph.js
@@ -67,6 +67,7 @@ module.exports = function levelgraph(leveldb, options) {
       return stream;
     }
     , get: utilities.wrapCallback('getStream')
+    , createQuery: utilities.createQuery
     , put: doAction('put', leveldb)
     , del: doAction('del', leveldb)
     , putStream: doActionStream('put', leveldb)

--- a/test/create_query.js
+++ b/test/create_query.js
@@ -1,0 +1,39 @@
+
+var levelgraph = require('../lib/levelgraph')
+  , createQuery = require('../lib/utilities').createQuery
+  , level = require('level-test')()
+  , path = require('path')
+  , osenv = require('osenv');
+
+describe('createQuery', function() {
+
+  var db, leveldb = leveldb;
+
+  beforeEach(function(done) {
+    leveldb = level();
+    db = levelgraph(leveldb);
+    db.put({ subject: 'a', predicate: 'b', object: 'c' }, done);
+  });
+
+  afterEach(function(done) {
+    db.close(done);
+  });
+
+  it('should get same results as levelgraph.get', function(done) {
+    db.get({ predicate: 'b' }, function(err, res) {
+      leveldb.createValueStream(db.createQuery({ predicate: 'b' }))
+        .on('data', function(data) {
+          console.log(data, res);
+          expect([data]).to.eql(res);
+          done();
+        })
+      ;
+    });
+  });
+
+  it('should be exposed in lib/utilities.js', function(done) {
+    expect(createQuery).to.eql(db.createQuery);
+    done();
+  });
+
+});


### PR DESCRIPTION
What do you think about adding `createQuery` to the API, so then you can use the raw levelup query with other modules, for example pass the query to `level-live-stream`?
