### PR TITLE
Object.keys() of a String throws exception on node < 1

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -25,6 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 var CallbackStream = require('callback-stream')
   , Variable       = require('./variable')
+  , lodashKeys     = require('lodash.keys')
   , defs = {
       spo: ['subject', 'predicate', 'object'],
       sop: ['subject', 'object', 'predicate'],
@@ -221,7 +222,7 @@ module.exports.materializer = materializer;
   };
 
   var objectMask = function objectMask(criteria, object) {
-    return Object.keys(object).
+    return lodashKeys(object).
       filter(a).
       filter(function(key) {
         return criteria(object, key);

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "sinon": "~1.10.3",
     "sinon-chai": "^2.6.0",
     "uglify-js": "~2.4.8",
-    "zuul": "^3.0.0"
+    "zuul": "^3.0.0",
+    "lodash.keys": "^4.0.6"
   },
   "dependencies": {
     "async": "~1.2.1",


### PR DESCRIPTION
On node versions < 1 Object.keys() of a String instance will produce an
exception. However on later node versions everything works fine. The
library lodash.keys provides a safe implementation for keys.

This change is needed to fix a pull request for levelgraph-jsonld https://github.com/mcollina/levelgraph-jsonld/pull/32