### PR TITLE
Adding failing multilevel join with two results test for #145.

### DIFF
--- a/test/multilevel_spec.js
+++ b/test/multilevel_spec.js
@@ -41,6 +41,36 @@ describe('a multileveled triple store', function() {
     });
   });
 
+  it('should search many triples', function(done) {
+    var triple1 = { subject: 'a1', predicate: 'b', object: 'c' };
+    var triple2 = { subject: 'a2', predicate: 'b', object: 'c' };
+    graph.put([triple1, triple2], function() {
+      graph.search([{ subject: graph.v('x'), predicate: 'b', object: 'c' }], function(err, list) {
+        expect(list).to.eql([{ x: 'a1' }, {x: 'a2'}]);
+        done();
+      });
+    });
+  });
+
+  it('should do a join with two results', function(done) {
+    graph.put(require('./fixture/foaf'), function(done) {
+      graph.search([{
+        subject: graph.v('x'),
+        predicate: 'friend',
+        object: 'marco'
+      }, {
+        subject: graph.v('x'),
+        predicate: 'friend',
+        object: 'matteo'
+      }], function(err, results) {
+        expect(results).to.have.property('length', 2);
+        expect(results[0]).to.have.property('x', 'daniele');
+        expect(results[1]).to.have.property('x', 'lucio');
+        done();
+      });
+    });
+  });
+
   it('should put a triple with a stream', function(done) {
     var triple = { subject: 'a', predicate: 'b', object: 'c' };
     var stream = graph.putStream();


### PR DESCRIPTION
This returns `this._readStream.read is not a function` when joining two results.