### PR TITLE
Allow non-array search parameter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: node_js
 sudo: false
 matrix:
   include:
-    - node_js: '0.10'
-      env: NO_WEB=1
-    - node_js: '0.12'
-      env: NO_WEB=1
     - node_js: '4'
       env: NO_WEB=1
     - node_js: '6'
+      env: NO_WEB=1
+    - node_js: '7'
       env: NO_WEB=1
     - node_js: '4'
       env: NO_WEB=

--- a/lib/levelgraph.js
+++ b/lib/levelgraph.js
@@ -126,6 +126,8 @@ searchStream = function(db, options) {
     if (!query || query.length === 0) {
       result.end();
       return result;
+    } else if (!Array.isArray(query)) {
+      query = [ query ];
     }
 
     planner(query, function(err, newquery) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jshint": "^2.9.2",
     "level-browserify": "^1.0.1",
     "level-sublevel": "^6.4.6",
-    "level-test": "^2.0.0",
+    "memdb": "^1.3.1",
     "mocha": "^2.2.5",
     "multilevel": "^7.2.0",
     "osenv": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levelgraph",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "A graph database for Node.js and the browser built on top of LevelUp",
   "main": "lib/levelgraph.js",
   "scripts": {

--- a/test/abstract_join_algorithm.js
+++ b/test/abstract_join_algorithm.js
@@ -29,6 +29,18 @@ module.exports = function(joinAlgorithm) {
     });
   });
 
+  it('should support non-array search parameter', function(done) {
+    db.search({
+      subject: db.v('x'),
+      predicate: 'friend',
+      object: 'daniele'
+    }, function(err, results) {
+      expect(results).to.have.property('length', 1);
+      expect(results[0]).to.have.property('x', 'matteo');
+      done();
+    });
+  });
+
   it('should do a join with two results', function(done) {
     db.search([{
       subject: db.v('x'),

--- a/test/abstract_join_algorithm.js
+++ b/test/abstract_join_algorithm.js
@@ -1,6 +1,6 @@
 
 var levelgraph = require('../lib/levelgraph');
-var level = require('level-test')();
+var level = require('memdb');
 
 module.exports = function(joinAlgorithm) {
 

--- a/test/abstract_sublevel_support.js
+++ b/test/abstract_sublevel_support.js
@@ -1,6 +1,6 @@
 
 var levelgraph = require('../lib/levelgraph')
-  , level = require('level-test')()
+  , level = require('memdb')
   , osenv = require('osenv');
 
 module.exports = function(sublevel) {

--- a/test/create_query.js
+++ b/test/create_query.js
@@ -1,7 +1,7 @@
 
 var levelgraph = require('../lib/levelgraph')
   , createQuery = require('../lib/utilities').createQuery
-  , level = require('level-test')()
+  , level = require('memdb')
   , path = require('path')
   , osenv = require('osenv');
 

--- a/test/creation_api_spec.js
+++ b/test/creation_api_spec.js
@@ -1,6 +1,6 @@
 
 var levelgraph = require('../lib/levelgraph')
-  , level = require('level-test')(),
+  , level = require('memdb'),
   os = require('os'),
   path = require('path');
 

--- a/test/multilevel_spec.js
+++ b/test/multilevel_spec.js
@@ -1,6 +1,6 @@
 var levelgraph = require('../lib/levelgraph')
   , multilevel = require('multilevel')
-  , level = require('level-test')()
+  , level = require('memdb')
   , osenv = require('osenv');
 
 describe('a multileveled triple store', function() {

--- a/test/navigator_spec.js
+++ b/test/navigator_spec.js
@@ -1,6 +1,6 @@
 
 var levelgraph = require('../lib/levelgraph')
-  , level = require('level-test')();
+  , level = require('memdb');
 
 describe('navigator', function() {
 

--- a/test/properties_spec.js
+++ b/test/properties_spec.js
@@ -1,5 +1,5 @@
 var levelgraph = require('../lib/levelgraph')
-  , level = require('level-test')();
+  , level = require('memdb');
 
 describe('a basic triple store', function() {
 

--- a/test/triple_store_spec.js
+++ b/test/triple_store_spec.js
@@ -1,6 +1,6 @@
 
 var levelgraph = require('../lib/levelgraph')
-  , level = require('level-test')()
+  , level = require('memdb')
   , path = require('path')
   , osenv = require('osenv');
 

--- a/test/triple_unicode_store_spec.js
+++ b/test/triple_unicode_store_spec.js
@@ -1,6 +1,6 @@
 
 var levelgraph = require('../lib/levelgraph')
-  , level = require('level-test')()
+  , level = require('memdb')
   , path = require('path')
   , osenv = require('osenv');
 


### PR DESCRIPTION
 This fails levelgraph-jsonld tests when updating dependencies. Just added a test and will submit a fix.