### PR TITLE
shorten batch to 5 indices

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -32,7 +32,7 @@ var CallbackStream = require('callback-stream')
       pos: ['predicate', 'object', 'subject'],
       pso: ['predicate', 'subject', 'object'],
       ops: ['object', 'predicate', 'subject'],
-      osp: ['object', 'subject', 'predicate']
+      // osp: ['object', 'subject', 'predicate']
     };
 var upperBoundChar = '\udbff\udfff';
 

--- a/test/triple_store_spec.js
+++ b/test/triple_store_spec.js
@@ -657,7 +657,7 @@ describe('generateBatch', function () {
   it('should generate a batch from a triple', function() {
     var triple = { subject: 'a', predicate: 'b', object: 'c' };
     var ops = db.generateBatch(triple);
-    expect(ops).to.have.property('length', 6);
+    expect(ops).to.have.property('length', 5);
     ops.forEach(function (op) {
       expect(op).to.have.property('type', 'put');
       expect(JSON.parse(op.value)).to.eql(triple);
@@ -667,7 +667,7 @@ describe('generateBatch', function () {
   it('should generate a batch of type', function() {
     var triple = { subject: 'a', predicate: 'b', object: 'c' };
     var ops = db.generateBatch(triple, 'del');
-    expect(ops).to.have.property('length', 6);
+    expect(ops).to.have.property('length', 5);
     ops.forEach(function (op) {
       expect(op).to.have.property('type', 'del');
       expect(JSON.parse(op.value)).to.eql(triple);

--- a/test/triple_unicode_store_spec.js
+++ b/test/triple_unicode_store_spec.js
@@ -451,7 +451,7 @@ describe('generateBatch', function () {
   it('should generate a batch from a triple', function() {
     var triple = { subject: '车', predicate: '是', object: '交通工具' };
     var ops = db.generateBatch(triple);
-    expect(ops).to.have.property('length', 6);
+    expect(ops).to.have.property('length', 5);
     ops.forEach(function (op) {
       expect(op).to.have.property('type', 'put');
       expect(JSON.parse(op.value)).to.eql(triple);
@@ -461,7 +461,7 @@ describe('generateBatch', function () {
   it('should generate a batch of type', function() {
     var triple = { subject: '车', predicate: '是', object: '交通工具' };
     var ops = db.generateBatch(triple, 'del');
-    expect(ops).to.have.property('length', 6);
+    expect(ops).to.have.property('length', 5);
     ops.forEach(function (op) {
       expect(op).to.have.property('type', 'del');
       expect(JSON.parse(op.value)).to.eql(triple);


### PR DESCRIPTION
@mcollina, this is my pull request about #167.

As you can see, I removed last item from the `defs` array. Doing so, I shortened the batch to 5. I updated tests accordingly and everything seems to work.

I'd like to revisit the optimization with you: if I understand your code, you cycle the `defs` array to find just *ONE* index to query. If I'm correct, when input pattern is `{ subject: 'subject', object: 'object' }` there's no chance for `OSP` index to be elected (the last item, the one I removed); you always elect `SOP`. That's why I think that 5 indices suffice.

Generally speaking, the input pattern can be one of `S, P, O, SP, SO, PO, SPO` (order doesn't matter because you use an object). If you elect an index to query for each and every pattern, you will end up with 5 indices instead of 6. Please, try yourself to confirm.

A last word on the undocumented feature `preferiteIndex`

1. it will be affected by the optimization because you can't specify `OSP` anymore;
2. I think it should be called `preferIndex` or `preferredIndex`.

Thanks for levelgraph and please, let me know.